### PR TITLE
GH-15: Normalize GitHub repository URLs to HTTPS

### DIFF
--- a/backend/ingestion/github_client.py
+++ b/backend/ingestion/github_client.py
@@ -21,6 +21,11 @@ _GITHUB_URL_RE = re.compile(r"^https://github\.com/[\w.-]+/[\w.-]+/?$")
 
 def _validate_repo_url(url: str) -> str:
     url = url.strip().lower()
+    if not url.startswith("https://"):
+        if url.startswith("http://"):
+            url = "https://" + url[len("http://"):]
+        else:
+            url = "https://" + url
     if not _GITHUB_URL_RE.match(url):
         raise ValueError(
             f"Invalid GitHub repo URL: '{url}'. Must be https://github.com/owner/repo"


### PR DESCRIPTION
This change improves URL handling in the GitHub ingestion client by normalizing repository URLs to ensure they consistently use the `https://` scheme before validation.

### Changes

* Converts `http://` URLs to `https://`
* Prepends `https://` when no scheme is provided
* Ensures normalized URLs are validated against the existing GitHub URL regex

### Motivation

Users may provide repository URLs in different formats (with `http`, without a scheme, etc.). Without normalization, valid repositories could be rejected unnecessarily during validation.

### Behavior Impact

* Accepts:
  * `https://github.com/owner/repo`
  * `http://github.com/owner/repo` → normalized to https
  * `github.com/owner/repo` → normalized to https
* Rejects any URL that does not match the expected GitHub repository pattern after normalization

### Notes

This change improves robustness of ingestion without altering downstream validation rules or accepted repository structure.

Closes #15 